### PR TITLE
Issue 3: Added Melee DPS implementation, and result/character structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.vscode/

--- a/src/AttackType.cpp
+++ b/src/AttackType.cpp
@@ -1,0 +1,8 @@
+#include "AttackType.hpp"
+
+float AttackType::calc_dps(const attacker& attacker, const defender& defender)
+{
+    float dmg_per_hit = calc_max_hit(attacker) * calc_chance_to_hit(attacker, defender) / 2;
+    result_.dps_ = dmg_per_hit / (0.6 * attacker.loadout_.weapon_.attack_speed_);
+    return result_.dps_;
+}

--- a/src/AttackType.hpp
+++ b/src/AttackType.hpp
@@ -1,0 +1,42 @@
+#include "structures.hpp"
+
+#include <cmath>
+#include <stdexcept>
+
+class AttackType
+{
+    public:
+        float calc_dps(const attacker& attacker, const defender& defender);
+
+        virtual int   calc_max_hit(const attacker& attacker)                                    = 0;
+        virtual float calc_chance_to_hit(const attacker& attacker, const defender& defender)    = 0;
+        virtual int   calc_attack_roll(const attacker& attacker)                                = 0;
+        virtual int   calc_defence_roll(const attack_style atk_style, const defender& defender) = 0;
+
+        const Result& get_result() const { return result_; }
+    
+    protected:
+        Result result_;
+};
+
+/*
+class RangedAttack : public AttackType
+{
+    public:
+        int calc_max_hit(const attacker& attacker) override;
+        float calc_chance_to_hit(const attacker& attacker, const defender& defender) override;
+    
+    private:
+        int sum_ranged_bonus(const gear_set& gear_set) const;
+};
+
+class MagicAttack : public AttackType
+{
+    public:
+        int calc_max_hit(const attacker& attacker) override;
+        float calc_chance_to_hit(const attacker& attacker, const defender& defender) override;
+    
+    private:
+        float sum_magic_bonus(const gear_set& gear_set) const;
+};
+*/

--- a/src/DPSCalculator.cpp
+++ b/src/DPSCalculator.cpp
@@ -1,0 +1,53 @@
+#include "DPSCalculator.hpp"
+#include "MeleeAttack.hpp"
+
+#include <iostream>
+#include <memory>
+
+void DPSCalculator::calculate_all_dps()
+{
+    for (auto& attacker : attackers_)
+    {
+        std::vector<Result> results;
+        for (auto& defender : defenders_)
+        {
+            std::unique_ptr<AttackType> attack = nullptr;
+            switch (attacker.loadout_.weapon_.attack_style_)
+            {
+                case attack_style::stab:
+                case attack_style::slash:
+                case attack_style::crush:
+                    attack = std::make_unique<MeleeAttack>();
+                    break;
+                case attack_style::range:
+                    //attack = std::make_unique<RangedAttack>();
+                    break;
+                case attack_style::magic:
+                    //attack = std::make_unique<MagicAttack>();
+                    break;
+                default:
+                    throw std::invalid_argument("Invalid attack style");
+            }
+            attack->calc_dps(attacker, defender);
+            results.push_back(attack->get_result());
+        }
+        results_.push_back(results);
+    }
+}
+
+void DPSCalculator::print_results()
+{
+    for (size_t i = 0; i < attackers_.size(); i++)
+    {
+        for (size_t j = 0; j < defenders_.size(); j++)
+        {
+            std::cout << i << " vs " << j << std::endl;
+            std::cout << "DPS: " << results_[i][j].dps_ << std::endl;
+            std::cout << "Max hit: " << results_[i][j].max_hit_ << std::endl;
+            std::cout << "Max attack roll: " << results_[i][j].max_attack_roll_ << std::endl;
+            std::cout << "Max defence roll: " << results_[i][j].max_defence_roll_ << std::endl;
+            std::cout << "Chance to hit: " << results_[i][j].chance_to_hit_ << std::endl;
+            std::cout << std::endl;
+        }
+    }
+}

--- a/src/DPSCalculator.hpp
+++ b/src/DPSCalculator.hpp
@@ -1,0 +1,17 @@
+#include <vector>
+
+#include "structures.hpp"
+
+class DPSCalculator
+{
+    public:
+        DPSCalculator(std::vector<attacker> attackers, std::vector<defender> defenders) : attackers_(attackers), defenders_(defenders) {}
+
+        void calculate_all_dps();
+        void print_results();
+
+    private:
+        std::vector<std::vector<Result>> results_;
+        std::vector<attacker> attackers_;
+        std::vector<defender> defenders_;
+};

--- a/src/MeleeAttack.cpp
+++ b/src/MeleeAttack.cpp
@@ -1,0 +1,165 @@
+#include "MeleeAttack.hpp"
+
+int MeleeAttack::calc_effective_strength(const attacker& attacker) const
+{
+    int effective_strength = attacker.skills_.strength_;
+    switch (attacker.potion_)
+    {
+        case super_strength:
+            effective_strength += 5 + (attacker.skills_.strength_ * 0.15); break;
+        case smelling_salts:
+            effective_strength += 11 + (attacker.skills_.strength_ * 0.16); break;
+    }
+    
+    if (attacker.prayer_ == piety)
+        effective_strength = std::floor(effective_strength * 1.23);
+    
+    effective_strength += 3 + 8; // aggressive style +3
+
+    if (attacker.loadout_.weapon_.name_ ==  "Void melee helm"  &&
+        (attacker.loadout_.weapon_.name_ == "Void knight top"  || attacker.loadout_.body_.name_ == "Elite void top")  &&
+        (attacker.loadout_.weapon_.name_ == "Void knight robe" || attacker.loadout_.legs_.name_ == "Elite void robe") && 
+        attacker.loadout_.weapon_.name_ == "Void knight gloves")
+    {
+        effective_strength = std::floor(effective_strength * 1.10);
+    }
+    
+    return effective_strength;
+}
+
+int MeleeAttack::sum_attack_bonus(const gear_set& gear_set) const
+{
+    switch (gear_set.weapon_.attack_style_)
+    {
+        case stab:  return gear_set.weapon_.stab_atk_bonus_  + gear_set.shield_.stab_atk_bonus_  + gear_set.helmet_.stab_atk_bonus_  + gear_set.body_.stab_atk_bonus_   + 
+                             gear_set.legs_.stab_atk_bonus_  + gear_set.gloves_.stab_atk_bonus_  + gear_set.boots_.stab_atk_bonus_  + gear_set.amulet_.stab_atk_bonus_  + 
+                             gear_set.ring_.stab_atk_bonus_  + gear_set.cape_.stab_atk_bonus_   + gear_set.ammo_.stab_atk_bonus_;
+        case slash: return gear_set.weapon_.slash_atk_bonus_ + gear_set.shield_.slash_atk_bonus_ + gear_set.helmet_.slash_atk_bonus_ + gear_set.body_.slash_atk_bonus_  + 
+                             gear_set.legs_.slash_atk_bonus_ + gear_set.gloves_.slash_atk_bonus_ + gear_set.boots_.slash_atk_bonus_ + gear_set.amulet_.slash_atk_bonus_ + 
+                             gear_set.ring_.slash_atk_bonus_ + gear_set.cape_.slash_atk_bonus_   + gear_set.ammo_.slash_atk_bonus_;
+        case crush: return gear_set.weapon_.crush_atk_bonus_ + gear_set.shield_.crush_atk_bonus_ + gear_set.helmet_.crush_atk_bonus_ + gear_set.body_.crush_atk_bonus_  + 
+                             gear_set.legs_.crush_atk_bonus_ + gear_set.gloves_.crush_atk_bonus_ + gear_set.boots_.crush_atk_bonus_ + gear_set.amulet_.crush_atk_bonus_ + 
+                             gear_set.ring_.crush_atk_bonus_ + gear_set.cape_.crush_atk_bonus_   + gear_set.ammo_.crush_atk_bonus_;
+        case range:
+        case magic:
+            throw std::runtime_error("Invalid attack style for melee attack.");
+    }
+}
+
+int MeleeAttack::sum_strength_bonus(const gear_set& gear_set) const
+{
+    return gear_set.weapon_.str_bonus_ + gear_set.shield_.str_bonus_ + gear_set.helmet_.str_bonus_ + gear_set.body_.str_bonus_   + 
+           gear_set.legs_.str_bonus_   + gear_set.gloves_.str_bonus_ + gear_set.boots_.str_bonus_  + gear_set.amulet_.str_bonus_ + 
+           gear_set.ring_.str_bonus_   + gear_set.cape_.str_bonus_   + gear_set.ammo_.str_bonus_;
+}
+
+int MeleeAttack::calc_max_hit(const attacker& attacker)
+{
+    int effective_strength = calc_effective_strength(attacker);
+    effective_strength *= sum_strength_bonus(attacker.loadout_) + 64;
+    effective_strength = std::floor((effective_strength + 320) / 640.0);
+    
+    float gear_bonus = 1.0;
+    if (attacker.loadout_.weapon_.name_ == "Slayer helmet (i)" ||
+        attacker.loadout_.weapon_.name_ == "Slayer helmet"     || 
+        attacker.loadout_.amulet_.name_ == "Salve amulet")
+    {
+        gear_bonus = 7.0 / 6.0;
+    }
+    if (attacker.loadout_.amulet_.name_ == "Salve amulet (ei)")
+    {
+        gear_bonus = 1.2;
+    }
+
+    result_.max_hit_ = std::floor(effective_strength * gear_bonus);
+    return result_.max_hit_;
+}
+
+int MeleeAttack::calc_effective_attack(const attacker& attacker) const
+{
+    int effective_attack = attacker.skills_.attack_;
+    switch (attacker.potion_)
+    {
+        case super_attack:
+            effective_attack += 5 + (attacker.skills_.attack_ * 0.15); break;
+        case smelling_salts:
+            effective_attack += 11 + (attacker.skills_.attack_ * 0.16); break;
+    }
+    
+    if (attacker.prayer_ == piety)
+        effective_attack = std::floor(effective_attack * 1.20);
+    
+    effective_attack += 3 + 8; // aggressive style +3
+
+    if (attacker.loadout_.weapon_.name_ ==  "Void melee helm"  &&
+        (attacker.loadout_.weapon_.name_ == "Void knight top"  || attacker.loadout_.body_.name_ == "Elite void top")  &&
+        (attacker.loadout_.weapon_.name_ == "Void knight robe" || attacker.loadout_.legs_.name_ == "Elite void robe") && 
+        attacker.loadout_.weapon_.name_ == "Void knight gloves")
+    {
+        effective_attack = std::floor(effective_attack * 1.10);
+    }
+    
+    return effective_attack;
+}
+
+int MeleeAttack::calc_attack_roll(const attacker& attacker)
+{
+    int attack_roll = calc_effective_attack(attacker);
+    attack_roll *= sum_attack_bonus(attacker.loadout_) + 64;
+
+    float gear_bonus = 1.0;
+    if (attacker.loadout_.weapon_.name_ == "Slayer helmet (i)" ||
+        attacker.loadout_.weapon_.name_ == "Slayer helmet"     || 
+        attacker.loadout_.amulet_.name_ == "Salve amulet")
+    {
+        gear_bonus = 7.0 / 6.0;
+    }
+    if (attacker.loadout_.amulet_.name_ == "Salve amulet (ei)")
+    {
+        gear_bonus = 1.2;
+    }
+
+    result_.max_attack_roll_ = std::floor(attack_roll * gear_bonus);
+    return result_.max_attack_roll_;
+}
+
+int MeleeAttack::calc_defence_roll(const attack_style atk_style, const defender& defender)
+{
+    int defence_roll = defender.def_lvl_ + 9;
+    
+    int attack_style_bonus = 0;
+    switch (atk_style)
+    {
+        case stab:  attack_style_bonus = defender.stab_def_; break;
+        case slash: attack_style_bonus = defender.slash_def_; break;
+        case crush: attack_style_bonus = defender.crush_def_; break;
+
+        case range:
+        case magic:
+            throw std::runtime_error("Invalid attack style for melee attack.");
+    }
+
+    result_.max_defence_roll_ = std::floor(defence_roll * (attack_style_bonus + 64.0));
+    return result_.max_defence_roll_;
+}
+
+float MeleeAttack::calc_chance_to_hit(const attacker& attacker, const defender& defender)
+{
+    int attack_roll = calc_attack_roll(attacker);
+    int defence_roll = calc_defence_roll(attacker.loadout_.weapon_.attack_style_, defender);
+
+    if (attack_roll > defence_roll)
+    {
+        float numerator = defence_roll + 2;
+        float denominator = 2 * (attack_roll + 1);
+        result_.chance_to_hit_ = 1 - (numerator / denominator);
+    }
+    else
+    {
+        float numerator = attack_roll;
+        float denominator = 2 * (defence_roll + 1);
+        result_.chance_to_hit_ = numerator / denominator;
+    }
+
+    return result_.chance_to_hit_;
+}

--- a/src/MeleeAttack.hpp
+++ b/src/MeleeAttack.hpp
@@ -1,0 +1,16 @@
+#include "AttackType.hpp"
+
+class MeleeAttack : public AttackType
+{
+    public:
+        int         calc_max_hit(const attacker& attacker)                                    override;
+        float       calc_chance_to_hit(const attacker& attacker, const defender& defender)    override;
+        virtual int calc_attack_roll(const attacker& attacker)                                override;
+        virtual int calc_defence_roll(const attack_style atk_style, const defender& defender) override;
+    
+    private:
+        int calc_effective_strength(const attacker& attacker) const;
+        int calc_effective_attack(const attacker& attacker)   const;
+        int sum_attack_bonus(const gear_set& gear_set)        const;
+        int sum_strength_bonus(const gear_set& gear_set)      const;
+};

--- a/src/dpscalc.cpp
+++ b/src/dpscalc.cpp
@@ -1,7 +1,11 @@
+#include "DPSCalculator.hpp"
+
 #include <iostream>
 
 int main()
 {
-    std::cout << "Hello World!";
+    std::cout << "Hello World!\n";
+    DPSCalculator dps_calculator({}, {});
+    std::cout << "DPS calculator created!\n";
     return 0;
 }

--- a/src/structures.hpp
+++ b/src/structures.hpp
@@ -1,0 +1,132 @@
+#include <string>
+
+enum attack_style
+{
+    stab,
+    slash,
+    crush,
+    magic,
+    range
+};
+
+struct equippable_item
+{
+    std::string name_;
+    std::string examine_;
+
+    int stab_atk_bonus_;
+    int slash_atk_bonus_;
+    int crush_atk_bonus_;
+    int magic_atk_bonus_;
+    int range_atk_bonus_;
+
+    int stab_def_bonus_;
+    int slash_def_bonus_;
+    int crush_def_bonus_;
+    int magic_def_bonus_;
+    int range_def_bonus_;
+
+    int str_bonus_;
+    int rng_bonus_;
+    float mag_bonus_;
+    int pray_bonus_;
+};
+
+struct weapon : equippable_item
+{
+    int attack_speed_;
+    attack_style attack_style_;
+    bool special_attack_;
+};
+
+struct gear_set
+{
+    weapon weapon_;
+    equippable_item shield_;
+    equippable_item helmet_;
+    equippable_item body_;
+    equippable_item legs_;
+    equippable_item gloves_;
+    equippable_item boots_;
+    equippable_item amulet_;
+    equippable_item ring_;
+    equippable_item cape_;
+    equippable_item ammo_;
+};
+
+struct skills
+{
+    int attack_;
+    int strength_;
+    int defence_;
+    int ranged_;
+    int magic_;
+    int prayer_;
+};
+
+enum prayer
+{
+    no_prayer,
+    piety,
+    rigour,
+    augury
+};
+
+enum potion
+{
+    no_potion,
+    super_attack,
+    super_strength,
+    super_defence,
+    super_ranged,
+    super_magic,
+    smelling_salts
+};
+
+struct attacker
+{
+    gear_set loadout_;
+    skills skills_;
+    prayer prayer_;
+    potion potion_;
+    bool using_thrall_;
+};
+
+enum defender_type
+{
+    none,
+    undead,
+    demon,
+    dragon,
+    leafy,
+    xerician,
+    vampyre,
+    kalphite,
+    golem
+};
+
+struct defender
+{
+    defender_type type_;
+
+    int atk_lvl_;
+    int str_lvl_;
+    int def_lvl_;
+    int rng_lvl_;
+    int mag_lvl_;
+
+    int stab_def_;
+    int slash_def_;
+    int crush_def_;
+    int magic_def_;
+    int range_def_;
+};
+
+struct Result
+{
+    float dps_              = 0.0;
+    int   max_hit_          = 0;
+    float chance_to_hit_    = 0.0;
+    int   max_attack_roll_  = 0;
+    int   max_defence_roll_ = 0;
+};


### PR DESCRIPTION
This MR adds basic structures for runescape attackers and defenders, along with a basic DPS calculation implementation for melee weapons, without testing.

Melee DPS is implemented via the MeleeAttack class, a subclass of AttackType which contains virtual functions calc_dps, calc_max_hit, etc. I have left comments for future ranged and magic implementations. The AttackType is wrapped in a DPSCalculator object which allows multiple attackers and defenders, calculating DPS for all calculations, and including a function to print stats.

Now we need to make use of our csv files from Issue 2's resolution... and add a GUI :(