### PR TITLE
Issue 9: Added UnitTest, initial test CSVReaderTest object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set(SOURCES
     src/MeleeAttack.cpp
     src/CSVReader.cpp
     src/AttackType.cpp
+
+    tests/CSVReaderTest.cpp
 )
 
 # Create an executable

--- a/src/CSVReader.cpp
+++ b/src/CSVReader.cpp
@@ -18,7 +18,7 @@ bool CSVReader::read_csv()
 
         int col = 0;
         std::string key;
-        std::map<std::string, std::string> row_data;
+        CSVRow row_data;
         while (std::getline(row_stream, cell, ','))
         {
             if (row == 0)

--- a/src/CSVReader.hpp
+++ b/src/CSVReader.hpp
@@ -6,13 +6,14 @@
 #include <map>
 #include <vector>
 
-typedef std::map<std::string, std::map<std::string, std::string>> CSVData;
+typedef std::map<std::string, std::string> CSVRow;
+typedef std::map<std::string, CSVRow> CSVData;
 
 class CSVReader
 {
     public:
         CSVReader(const std::string& filename) : filename_(filename) {}
-        const std::map<std::string, std::string>& operator[](const std::string& key) const { return data_.at(key); }
+        const CSVRow& operator[](const std::string& key) const { return data_.at(key); }
 
         bool read_csv();
         const CSVData& get_data() const { return data_; }

--- a/src/dpscalc.cpp
+++ b/src/dpscalc.cpp
@@ -1,7 +1,39 @@
 #include "DPSCalculator.hpp"
+#include "../tests/CSVReaderTest.hpp"
 #include "CSVReader.hpp"
 
+#include <vector>
+#include <memory>
+
 #include <iostream>
+
+int do_unit_tests()
+{
+
+    // UNIT TESTING AND DEBUGGING HERE
+    // TODO: MOVE TO SEPARATE LOCATION WITH OWN CMAKE FILE
+    std::vector<std::unique_ptr<UnitTest>> unit_tests;
+    unit_tests.push_back(std::make_unique<CSVReaderTest>());
+
+    int fails, passes = 0;
+    std::cout << "\nRUNNING UNIT TESTS...\n";
+    for (const auto& unit_test : unit_tests)
+    {
+        if (!unit_test->condition())
+        {
+            std::cout << "Unit test failed: " << unit_test->get_name() << "\n";
+            fails++;
+            continue;
+        }
+        std::cout << "Unit test passed: " << unit_test->get_name() << "\n";
+        passes++;
+    }
+
+    std::cout << "Unit tests passed: " << passes << "\n";
+    std::cout << "Unit tests failed: " << fails << "\n";
+    std::cout << "UNIT TESTS COMPLETE\n";
+    return 0;
+}
 
 int main()
 {
@@ -11,13 +43,5 @@ int main()
     dps_calculator.calculate_all_dps();
     std::cout << "DPS calculator created!\n";
 
-    CSVReader csv_reader("../data/items.csv");
-    if (csv_reader.read_csv())
-        csv_reader.print_data();
-    
-    CSVReader csv_reader2("../data/monsters.csv");
-    if (csv_reader2.read_csv())
-        csv_reader2.print_data();
-
-    return 0;
+    return do_unit_tests();
 }

--- a/tests/CSVReaderTest.cpp
+++ b/tests/CSVReaderTest.cpp
@@ -1,0 +1,125 @@
+#include "CSVReaderTest.hpp"
+
+#include <memory>
+
+bool test_monsters(const CSVReader& csv_reader)
+{
+    std::unique_ptr<CSVRow> csv_zombie = std::make_unique<CSVRow>(csv_reader["Zombie"]);\
+    if (csv_zombie == nullptr)
+    {
+        std::cerr << "Failed to find Zombie in monsters.csv.\n";
+        return false;
+    }
+
+    if (std::stoi(csv_zombie->at("hitpoints")) != 54)
+    {
+        std::cerr << "Expected Zombie hp of 54, got " << csv_zombie->at("hitpoints") << ".\n";
+        return false;
+    }
+
+    if (std::stoi(csv_zombie->at("magic_level")) != 1)
+    {
+        std::cerr << "Expected Zombie magic of 1, got " << csv_zombie->at("magic_level") << ".\n";
+        return false;
+    }
+    
+    if (std::stoi(csv_zombie->at("attack_level")) != 160)
+    {
+        std::cerr << "Expected Zombie attack of 160, got " << csv_zombie->at("attack_level") << ".\n";
+        return false;
+    }
+
+    if (std::stoi(csv_zombie->at("defence_level")) != 62)
+    {
+        std::cerr << "Expected Zombie defence of 62, got " << csv_zombie->at("defence_level") << ".\n";
+        return false;
+    }
+
+    if (std::stoi(csv_zombie->at("strength_level")) != 1)
+    {
+        std::cerr << "Expected Zombie strength of 1, got " << csv_zombie->at("strength_level") << ".\n";
+        return false;  
+    }
+
+    std::unique_ptr<CSVRow> csv_dragon = std::make_unique<CSVRow>(csv_reader["Adamant dragon"]);
+    if (csv_dragon == nullptr)
+    {
+        std::cerr << "Failed to find Adamant dragon in monsters.csv.\n";
+        return false;
+    }
+
+    return true;
+}
+
+bool test_items(const CSVReader& csv_reader)
+{
+    std::unique_ptr<CSVRow> csv_item = std::make_unique<CSVRow>(csv_reader["Slayer cape"]);
+    if (csv_item == nullptr)
+    {
+        std::cerr << "Failed to find Slayer cape in items.csv.\n";
+        return false;
+    }
+
+    if (csv_item->at("equipable_weapon") != "False")
+    {
+        std::cerr << "Expected Slayer cape to not be equipable as a weapon, got " << csv_item->at("equipable_weapon") << ".\n";
+        return false;
+    }
+
+    if (csv_item->at("attack_stab") != "0")
+    {
+        std::cerr << "Expected Slayer cape to have 0 stab attack, got " << csv_item->at("attack_stab") << ".\n";
+        return false;
+    }
+
+    if (csv_item->at("attack_slash") != "0")
+    {
+        std::cerr << "Expected Slayer cape to have 0 slash attack, got " << csv_item->at("attack_slash") << ".\n";
+        return false;
+    }
+
+    if (csv_item->at("attack_crush") != "0")
+    {
+        std::cerr << "Expected Slayer cape to have 0 crush attack, got " << csv_item->at("attack_crush") << ".\n";
+        return false;
+    }
+
+    if (csv_item->at("defence_stab") != "9")
+    {
+        std::cerr << "Expected Slayer cape to have 9 stab defence, got " << csv_item->at("defence_stab") << ".\n";
+        return false;
+    }
+
+    if (csv_item->at("defence_slash") != "9")
+    {
+        std::cerr << "Expected Slayer cape to have 9 slash defence, got " << csv_item->at("defence_slash") << ".\n";
+        return false;
+    }
+
+    if (csv_item->at("defence_crush") != "9")
+    {
+        std::cerr << "Expected Slayer cape to have 9 crush defence, got " << csv_item->at("defence_crush") << ".\n";
+        return false;
+    }
+
+    return true;
+}
+
+bool CSVReaderTest::condition() const
+{
+    CSVReader csv_reader("../data/items.csv");
+    if (!csv_reader.read_csv())
+    {
+        std::cout << "Failed to read items.csv!\n";
+        return false;
+    }
+
+    CSVReader csv_reader2("../data/monsters.csv");
+    if (!csv_reader2.read_csv())
+    {
+        std::cout << "Failed to read monsters.csv!\n";
+        return false;
+    }
+
+    return test_items(csv_reader) && test_monsters(csv_reader2);
+}

--- a/tests/CSVReaderTest.hpp
+++ b/tests/CSVReaderTest.hpp
@@ -1,0 +1,17 @@
+#ifndef CSVREADERTEST_HPP_
+#define CSVREADERTEST_HPP_
+
+#include "UnitTest.hpp"
+#include "../src/CSVReader.hpp"
+
+bool test_monsters(const CSVReader& csv_reader);
+bool test_items(const CSVReader& csv_reader);
+
+class CSVReaderTest : public UnitTest
+{
+    public:
+        CSVReaderTest() : UnitTest("CSVReaderTest") {}
+        bool condition() const override;
+};
+
+#endif // CSVREADERTEST_HPP_

--- a/tests/UnitTest.hpp
+++ b/tests/UnitTest.hpp
@@ -1,0 +1,27 @@
+#ifndef UNITTEST_HPP_
+#define UNITTEST_HPP_
+
+#include <string>
+
+class UnitTest
+{
+    public:
+        UnitTest(const std::string& name) : name_(name) {}
+
+        bool perform_test()
+        {
+            result_ = condition();
+            return result_;
+        }
+        
+        virtual bool condition() const = 0;
+
+        bool get_result() const { return result_; }
+        const std::string& get_name() const { return name_; }
+
+    private:
+        std::string           name_;
+        bool                  result_;
+};
+
+#endif // UNITTEST_HPP_


### PR DESCRIPTION
This MR adds a general `UnitTest` object to implement unit tests in the `/tests/` folder, along with the first unit test, `CSVReaderTest`. Right now it's tested via a main function, we should have a separate cmake build for it instead.